### PR TITLE
Fix of the script for AADHI scenarios cleaning

### DIFF
--- a/ext-tools/sc-copy/utils.py
+++ b/ext-tools/sc-copy/utils.py
@@ -11,7 +11,7 @@ re_near_store_id = re.compile(r"nearStoreNumbers=([^&#]*)", re.IGNORECASE)
 re_date_from = re.compile(r"from=(\d{4}-\d{1,2}-\d{1,2})", re.IGNORECASE)
 re_date_to = re.compile(r"to=(\d{4}-\d{1,2}-\d{1,2})", re.IGNORECASE)
 
-aadhi_prefix = "aadhi.cma.r53.nordstrom.net:443/"
+aadhi_prefix_regex = re.compile(r"aadhi.cma.r53.nordstrom.net(:443)?/", re.IGNORECASE)
 
 headers_to_remove = ["connection", "content-length"]
 
@@ -59,7 +59,7 @@ def check_skip_by_code(src_path, id, code):
 
 
 def clear_url(url):
-    url = url.replace(aadhi_prefix, "")
+    url =  aadhi_prefix_regex.sub("", url)
 
     url = re.sub(re_apikey, "apikey=*", url)
     url = re.sub(re_code, "code=*", url)

--- a/ext-tools/sc-copy/utils_test.py
+++ b/ext-tools/sc-copy/utils_test.py
@@ -18,12 +18,12 @@ class UtilsTestCase(unittest.TestCase):
 
 
     def test_clear_url(self):
-        cases = [("https://test.net/guest?format=json&apikey=1234", "https://test.net/guest?format=json&apikey=*"),
-                 ("https://test.net/guest?apikey=1234", "https://test.net/guest?apikey=*"),
+        cases = [("https://aadhi.cma.r53.nordstrom.net:443/test.net/guest?format=json&apikey=1234", "https://test.net/guest?format=json&apikey=*"),
+                 ("https://aadhi.cma.r53.nordstrom.net/test.net/guest?apikey=1234", "https://test.net/guest?apikey=*"),
                  ("https://test.net/guest?apikey=1234&format=json", "https://test.net/guest?apikey=*&format=json"),
-                 ("https://test.net/guest?format=json&apikey=1234&code=67-98", "https://test.net/guest?format=json&apikey=*&code=*"),
+                 ("https://aadhi.cma.r53.nordstrom.net/test.net/guest?format=json&apikey=1234&code=67-98", "https://test.net/guest?format=json&apikey=*&code=*"),
                  ("https://test.net/guest?format=json&verifier=67-98-1", "https://test.net/guest?format=json&verifier=*"),
-                 ("https://test.net/guest?from=0&to=10&from=2019-1-1&to=2019-10-10", "https://test.net/guest?from=0&to=10&from=*&to=*"),
+                 ("https://aadhi.cma.r53.nordstrom.net:443/test.net/guest?from=0&to=10&from=2019-1-1&to=2019-10-10", "https://test.net/guest?from=0&to=10&from=*&to=*"),
                  ("https://test.net/guest?from=2019-10-10&to=2019-10-12&apikey=1234", "https://test.net/guest?from=*&to=*&apikey=*")]
 
         for cs in cases:


### PR DESCRIPTION
When recording http (not https) requests, port is not added to the host. Script for cleaning scenarios recorded from AADHI tests didn't expect that and fails to strip AADHI prefix.

Fixed this issue by looking for prefixes with or without port.